### PR TITLE
Clear the Gradio input during streaming updates

### DIFF
--- a/app.py
+++ b/app.py
@@ -15,8 +15,8 @@ from policy_agent import (
     PolicyAgentContext,
     build_agent,
     format_catalog_response,
-    run_agent,
     should_list_documents,
+    stream_agent,
 )
 from policy_store import PolicyStore
 from agents.run import AgentRunner as OpenAIAgentRunner
@@ -76,22 +76,49 @@ def create_interface() -> gr.Blocks:
 
         clear_button = gr.Button("Clear conversation", variant="secondary")
 
-        def respond(user_message: str, chat_history: List[dict], rag_history: List[Tuple[str, str]]):
+        async def respond(
+            user_message: str,
+            chat_history: List[dict],
+            rag_history: List[Tuple[str, str]],
+        ):
             rag_history = list(rag_history or [])
             normalized = user_message.strip()
+            cleared_input = gr.update(value="")
             if not normalized:
-                return "", chat_history, rag_history
+                yield cleared_input, chat_history, rag_history
+                return
+
+            updated_chat = list(chat_history or [])
+            updated_chat.append({"role": "user", "content": normalized})
+            assistant_entry = {"role": "assistant", "content": ""}
+            updated_chat.append(assistant_entry)
 
             if should_list_documents(normalized, context):
                 answer = format_catalog_response(context)
-            else:
-                answer = run_agent(agent, runner, context, rag_history, normalized)
+                assistant_entry["content"] = answer
+                rag_history.append((normalized, answer))
+                yield cleared_input, updated_chat, rag_history
+                return
 
-            rag_history.append((normalized, answer))
-            updated_chat = list(chat_history or [])
-            updated_chat.append({"role": "user", "content": normalized})
-            updated_chat.append({"role": "assistant", "content": answer})
-            return "", updated_chat, rag_history
+            prior_history = list(rag_history)
+            rag_history.append((normalized, ""))
+
+            # Show the user turn and placeholder assistant message immediately.
+            yield cleared_input, updated_chat, rag_history
+
+            emitted_chunk = False
+            async for chunk in stream_agent(agent, runner, context, prior_history, normalized):
+                assistant_entry["content"] += chunk
+                rag_history[-1] = (normalized, assistant_entry["content"])
+                emitted_chunk = True
+                yield cleared_input, updated_chat, rag_history
+
+            rag_history[-1] = (normalized, assistant_entry["content"])
+            if not emitted_chunk:
+                # Ensure the final state is delivered even if no streaming chunks were emitted.
+                yield cleared_input, updated_chat, rag_history
+
+            return
 
         for trigger in (message_box.submit, send_button.click):
             trigger(


### PR DESCRIPTION
## Summary
- return a Gradio textbox update while streaming so the pending user prompt is cleared immediately

## Testing
- python -m compileall app.py policy_agent.py
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68daebbc0e1c8324aebe23e1888d49d7