### PR TITLE
Add student authentication flows to Gradio interface

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,12 +4,13 @@ from __future__ import annotations
 import logging
 from functools import lru_cache
 from pathlib import Path
-from typing import List, Tuple
+from typing import Any, Dict, List, Tuple
 
 import gradio as gr
 from dotenv import load_dotenv
 from openai import OpenAI
 
+from auth_service import AuthService, EmailSender, EmailSettings, SecretHasher
 from config import load_settings
 from policy_agent import (
     PolicyAgentContext,
@@ -28,7 +29,7 @@ logger = logging.getLogger(__name__)
 
 
 @lru_cache(maxsize=1)
-def _bootstrap() -> tuple[PolicyAgentContext, object]:
+def _bootstrap() -> tuple[PolicyAgentContext, object, AuthService]:
     settings = load_settings()
     client = OpenAI(
         api_key=settings.openai_api_key,
@@ -42,11 +43,13 @@ def _bootstrap() -> tuple[PolicyAgentContext, object]:
         logger.info("Schema check skipped: %s", exc)
     agent = build_agent(settings)
     context = PolicyAgentContext(store=store, client=client, settings=settings)
-    return context, agent
+    email_sender = EmailSender(EmailSettings.from_settings(settings))
+    auth_service = AuthService(store, email_sender, SecretHasher())
+    return context, agent, auth_service
 
 
 def create_interface() -> gr.Blocks:
-    context, agent = _bootstrap()
+    context, agent, auth_service = _bootstrap()
     runner = OpenAIAgentRunner()
 
     with gr.Blocks(title="School Policy Assistant", theme=gr.themes.Soft()) as demo:
@@ -58,27 +61,340 @@ def create_interface() -> gr.Blocks:
                 """
             )
 
-        chat = gr.Chatbot(
-            label="Policy Assistant",
-            type="messages",
-            height=520,
-            show_copy_button=True,
-        )
+        session_state = gr.State({"authenticated": False, "username": None, "email": None})
         history_state = gr.State([])
+        registration_state = gr.State({"username": None, "email": None, "code_sent": False})
+        reset_state = gr.State({"email": None, "code_sent": False})
 
-        with gr.Row():
-            message_box = gr.Textbox(
-                label="Your question",
-                placeholder="Ask about attendance, grading, scholarships, ...",
-                scale=4,
+        status_bar = gr.Markdown("Not signed in.")
+        logout_button = gr.Button("Log out", variant="secondary", visible=False)
+
+        with gr.Tabs() as auth_tabs:
+            with gr.Tab("Login"):
+                login_username = gr.Textbox(label="Username", placeholder="nyustudent")
+                login_password = gr.Textbox(
+                    label="Password",
+                    type="password",
+                    placeholder="Enter your password",
+                )
+                login_button = gr.Button("Log in", variant="primary")
+                login_feedback = gr.Markdown(visible=False)
+
+            with gr.Tab("Register"):
+                register_username = gr.Textbox(
+                    label="Choose a username",
+                    placeholder="nyustudent",
+                )
+                register_email = gr.Textbox(
+                    label="NYU email",
+                    placeholder="netid@nyu.edu",
+                )
+                send_registration_code = gr.Button("Send verification code", variant="primary")
+                registration_feedback = gr.Markdown(visible=False)
+                register_code = gr.Textbox(
+                    label="6-digit verification code",
+                    placeholder="Enter the code from your email",
+                    visible=False,
+                )
+                register_password = gr.Textbox(
+                    label="Create a strong password",
+                    placeholder="At least 12 characters with mixed case, numbers, symbols",
+                    type="password",
+                    visible=False,
+                )
+                complete_registration = gr.Button(
+                    "Complete registration", variant="primary", visible=False
+                )
+
+            with gr.Tab("Forgot username/password"):
+                reset_email = gr.Textbox(
+                    label="NYU email",
+                    placeholder="netid@nyu.edu",
+                )
+                send_reset_code = gr.Button("Send reset email", variant="primary")
+                reset_feedback = gr.Markdown(visible=False)
+                reset_code = gr.Textbox(
+                    label="6-digit verification code",
+                    placeholder="Enter the code from your email",
+                    visible=False,
+                )
+                reset_password = gr.Textbox(
+                    label="New password",
+                    type="password",
+                    placeholder="At least 12 characters with mixed case, numbers, symbols",
+                    visible=False,
+                )
+                complete_reset = gr.Button("Reset password", variant="primary", visible=False)
+
+        with gr.Group(visible=False) as chat_container:
+            chat = gr.Chatbot(
+                label="Policy Assistant",
+                type="messages",
+                height=520,
+                show_copy_button=True,
             )
-            send_button = gr.Button("Send", variant="primary", scale=1)
+            with gr.Row():
+                message_box = gr.Textbox(
+                    label="Your question",
+                    placeholder="Ask about attendance, grading, scholarships, ...",
+                    scale=4,
+                    interactive=False,
+                )
+                send_button = gr.Button("Send", variant="primary", scale=1, interactive=False)
 
-        clear_button = gr.Button("Clear conversation", variant="secondary")
+            clear_button = gr.Button("Clear conversation", variant="secondary")
 
-        def respond(user_message: str, chat_history: List[dict], rag_history: List[Tuple[str, str]]):
+        def handle_login(
+            username: str,
+            password: str,
+            current_session: Dict[str, Any],
+        ) -> tuple[Any, ...]:
+            success, message, payload = auth_service.authenticate(username, password)
+            if success and payload:
+                session = {"authenticated": True, **payload}
+                return (
+                    gr.update(value=f"✅ {message}", visible=True),
+                    session,
+                    gr.update(value=f"Signed in as **{payload['username']}**."),
+                    gr.update(visible=True),
+                    gr.update(visible=True),
+                    gr.update(value="", interactive=True),
+                    gr.update(interactive=True),
+                    gr.update(value=""),
+                    gr.update(value=""),
+                )
+
+            session = {"authenticated": False, "username": None, "email": None}
+            return (
+                gr.update(value=f"❌ {message}", visible=True),
+                session,
+                gr.update(value="Not signed in."),
+                gr.update(visible=False),
+                gr.update(visible=False),
+                gr.update(value="", interactive=False),
+                gr.update(interactive=False),
+                gr.update(value=username),
+                gr.update(value=""),
+            )
+
+        login_button.click(
+            handle_login,
+            inputs=[login_username, login_password, session_state],
+            outputs=[
+                login_feedback,
+                session_state,
+                status_bar,
+                logout_button,
+                chat_container,
+                message_box,
+                send_button,
+                login_username,
+                login_password,
+            ],
+        )
+
+        def handle_logout(current_session: Dict[str, Any]) -> tuple[Any, ...]:
+            _ = current_session  # not used beyond signature
+            return (
+                gr.update(value="You have been signed out.", visible=True),
+                {"authenticated": False, "username": None, "email": None},
+                gr.update(value="Not signed in."),
+                gr.update(visible=False),
+                gr.update(visible=False),
+                gr.update(value="", interactive=False),
+                gr.update(interactive=False),
+                [],
+                [],
+            )
+
+        logout_button.click(
+            handle_logout,
+            inputs=[session_state],
+            outputs=[
+                login_feedback,
+                session_state,
+                status_bar,
+                logout_button,
+                chat_container,
+                message_box,
+                send_button,
+                chat,
+                history_state,
+            ],
+        )
+
+        def start_registration(
+            username: str,
+            email: str,
+            state: Dict[str, Any],
+        ) -> tuple[Any, ...]:
+            success, message, payload = auth_service.initiate_registration(username, email)
+            if success and payload:
+                new_state = {"code_sent": True, **payload}
+                return (
+                    gr.update(value=f"✅ {message}", visible=True),
+                    new_state,
+                    gr.update(value="", visible=True),
+                    gr.update(value="", visible=True),
+                    gr.update(visible=True),
+                    gr.update(value=payload["username"]),
+                    gr.update(value=payload["email"]),
+                )
+
+            keep_state = state or {"code_sent": False, "username": None, "email": None}
+            active = bool(keep_state.get("code_sent"))
+            return (
+                gr.update(value=f"❌ {message}", visible=True),
+                keep_state,
+                gr.update(value="", visible=active),
+                gr.update(value="", visible=active),
+                gr.update(visible=active),
+                gr.update(value=username),
+                gr.update(value=email),
+            )
+
+        send_registration_code.click(
+            start_registration,
+            inputs=[register_username, register_email, registration_state],
+            outputs=[
+                registration_feedback,
+                registration_state,
+                register_code,
+                register_password,
+                complete_registration,
+                register_username,
+                register_email,
+            ],
+        )
+
+        def finish_registration(
+            code: str,
+            password: str,
+            state: Dict[str, Any],
+        ) -> tuple[Any, ...]:
+            success, message = auth_service.complete_registration(state or {}, code, password)
+            if success:
+                return (
+                    gr.update(value=f"✅ {message}", visible=True),
+                    {"username": None, "email": None, "code_sent": False},
+                    gr.update(value="", visible=False),
+                    gr.update(value="", visible=False),
+                    gr.update(visible=False),
+                    gr.update(value=""),
+                    gr.update(value=""),
+                )
+
+            keep_state = state or {"username": None, "email": None, "code_sent": False}
+            return (
+                gr.update(value=f"❌ {message}", visible=True),
+                keep_state,
+                gr.update(value=code, visible=True),
+                gr.update(value="", visible=True),
+                gr.update(visible=True),
+                gr.update(value=keep_state.get("username") or ""),
+                gr.update(value=keep_state.get("email") or ""),
+            )
+
+        complete_registration.click(
+            finish_registration,
+            inputs=[register_code, register_password, registration_state],
+            outputs=[
+                registration_feedback,
+                registration_state,
+                register_code,
+                register_password,
+                complete_registration,
+                register_username,
+                register_email,
+            ],
+        )
+
+        def start_reset(email: str, state: Dict[str, Any]) -> tuple[Any, ...]:
+            success, message, payload = auth_service.initiate_password_reset(email)
+            if success and payload:
+                new_state = {"code_sent": True, **payload}
+                return (
+                    gr.update(value=f"✅ {message}", visible=True),
+                    new_state,
+                    gr.update(value="", visible=True),
+                    gr.update(value="", visible=True),
+                    gr.update(visible=True),
+                    gr.update(value=payload["email"]),
+                )
+
+            keep_state = state or {"email": None, "code_sent": False}
+            active = bool(keep_state.get("code_sent"))
+            return (
+                gr.update(value=f"❌ {message}", visible=True),
+                keep_state,
+                gr.update(value="", visible=active),
+                gr.update(value="", visible=active),
+                gr.update(visible=active),
+                gr.update(value=email),
+            )
+
+        send_reset_code.click(
+            start_reset,
+            inputs=[reset_email, reset_state],
+            outputs=[
+                reset_feedback,
+                reset_state,
+                reset_code,
+                reset_password,
+                complete_reset,
+                reset_email,
+            ],
+        )
+
+        def finish_reset(
+            code: str,
+            password: str,
+            state: Dict[str, Any],
+        ) -> tuple[Any, ...]:
+            success, message = auth_service.complete_password_reset(state or {}, code, password)
+            if success:
+                return (
+                    gr.update(value=f"✅ {message}", visible=True),
+                    {"email": None, "code_sent": False},
+                    gr.update(value="", visible=False),
+                    gr.update(value="", visible=False),
+                    gr.update(visible=False),
+                    gr.update(value=""),
+                )
+
+            keep_state = state or {"email": None, "code_sent": False}
+            return (
+                gr.update(value=f"❌ {message}", visible=True),
+                keep_state,
+                gr.update(value=code, visible=True),
+                gr.update(value="", visible=True),
+                gr.update(visible=True),
+                gr.update(value=keep_state.get("email") or ""),
+            )
+
+        complete_reset.click(
+            finish_reset,
+            inputs=[reset_code, reset_password, reset_state],
+            outputs=[
+                reset_feedback,
+                reset_state,
+                reset_code,
+                reset_password,
+                complete_reset,
+                reset_email,
+            ],
+        )
+
+        def respond(
+            user_message: str,
+            chat_history: List[dict],
+            rag_history: List[Tuple[str, str]],
+            session: Dict[str, Any],
+        ):
             rag_history = list(rag_history or [])
             normalized = user_message.strip()
+            if not session or not session.get("authenticated"):
+                return "", chat_history, rag_history
             if not normalized:
                 return "", chat_history, rag_history
 
@@ -96,7 +412,7 @@ def create_interface() -> gr.Blocks:
         for trigger in (message_box.submit, send_button.click):
             trigger(
                 respond,
-                inputs=[message_box, chat, history_state],
+                inputs=[message_box, chat, history_state, session_state],
                 outputs=[message_box, chat, history_state],
             )
 

--- a/auth_service.py
+++ b/auth_service.py
@@ -1,0 +1,425 @@
+"""Authentication and user management helpers for the Gradio interface."""
+from __future__ import annotations
+
+import base64
+import binascii
+import hashlib
+import hmac
+import logging
+import re
+import secrets
+import smtplib
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from email.message import EmailMessage
+from typing import Any, Dict, Tuple
+
+from sqlalchemy import select
+
+from config import Settings
+from policy_store import PolicyStore, UserAccount
+
+
+logger = logging.getLogger(__name__)
+
+
+class SecretHasher:
+    """Hash and verify secrets using PBKDF2-HMAC."""
+
+    algorithm = "pbkdf2_sha256"
+    iterations = 310_000
+
+    def hash_secret(self, secret: str) -> str:
+        salt = secrets.token_bytes(16)
+        derived = hashlib.pbkdf2_hmac(
+            "sha256", secret.encode("utf-8"), salt, self.iterations
+        )
+        payload = "$".join(
+            (
+                self.algorithm,
+                str(self.iterations),
+                base64.b64encode(salt).decode("utf-8"),
+                base64.b64encode(derived).decode("utf-8"),
+            )
+        )
+        return payload
+
+    def verify_secret(self, secret: str, encoded: str) -> bool:
+        try:
+            algorithm, iteration_s, salt_b64, derived_b64 = encoded.split("$")
+        except ValueError:
+            logger.warning("Invalid secret hash format encountered.")
+            return False
+
+        if algorithm != self.algorithm:
+            logger.warning("Unsupported hashing algorithm: %s", algorithm)
+            return False
+
+        try:
+            iterations = int(iteration_s)
+        except ValueError:
+            logger.warning("Invalid iteration count in stored hash.")
+            return False
+
+        try:
+            salt = base64.b64decode(salt_b64)
+            expected = base64.b64decode(derived_b64)
+        except (ValueError, binascii.Error):
+            logger.warning("Failed to decode stored hash components.")
+            return False
+
+        candidate = hashlib.pbkdf2_hmac(
+            "sha256", secret.encode("utf-8"), salt, iterations
+        )
+        return hmac.compare_digest(candidate, expected)
+
+
+@dataclass
+class EmailSettings:
+    host: str | None
+    port: int | None
+    username: str | None
+    password: str | None
+    from_email: str | None
+    use_tls: bool
+    use_ssl: bool
+    dev_mode: bool
+
+    @classmethod
+    def from_settings(cls, settings: Settings) -> "EmailSettings":
+        host = getattr(settings, "smtp_host", None)
+        port = getattr(settings, "smtp_port", None)
+        username = getattr(settings, "smtp_username", None)
+        password = getattr(settings, "smtp_password", None)
+        from_email = getattr(settings, "smtp_from_email", None)
+        use_tls = getattr(settings, "smtp_use_tls", False)
+        use_ssl = getattr(settings, "smtp_use_ssl", False)
+        dev_mode = getattr(settings, "smtp_dev_mode", False)
+        if host is None:
+            dev_mode = True
+        return cls(
+            host=host,
+            port=port,
+            username=username,
+            password=password,
+            from_email=from_email,
+            use_tls=use_tls,
+            use_ssl=use_ssl,
+            dev_mode=dev_mode,
+        )
+
+
+class EmailSender:
+    """Send transactional emails with graceful development fallbacks."""
+
+    def __init__(self, settings: EmailSettings) -> None:
+        self.settings = settings
+
+    def send_verification_code(self, email: str, code: str, *, username: str) -> None:
+        subject = "Verify your School Policy Assistant account"
+        body = (
+            "Hello {username},\n\n"
+            "Use the following verification code to finish setting up your account: {code}.\n"
+            "The code expires in 15 minutes.\n\n"
+            "If you did not request this, please ignore this email."
+        ).format(username=username, code=code)
+        self._send(email, subject, body)
+
+    def send_reset_code(self, email: str, code: str, *, username: str) -> None:
+        subject = "Reset your School Policy Assistant password"
+        body = (
+            "Hello {username},\n\n"
+            "A password or username reset was requested for your account.\n"
+            "Use this verification code to proceed: {code}.\n"
+            "The code expires in 15 minutes.\n\n"
+            "If you did not request this change, contact support immediately."
+        ).format(username=username, code=code)
+        self._send(email, subject, body)
+
+    def _send(self, recipient: str, subject: str, body: str) -> None:
+        if self.settings.dev_mode:
+            logger.info(
+                "SMTP disabled or in dev mode — simulated email to %s with subject %s. Body: %s",
+                recipient,
+                subject,
+                body,
+            )
+            return
+
+        if not self.settings.host:
+            raise RuntimeError("SMTP host is not configured; cannot send email.")
+
+        port = self.settings.port or (465 if self.settings.use_ssl else 587)
+        from_email = self.settings.from_email or self.settings.username
+        if not from_email:
+            raise RuntimeError("SMTP_FROM_EMAIL or SMTP_USERNAME must be configured for sending email.")
+
+        message = EmailMessage()
+        message["To"] = recipient
+        message["From"] = from_email
+        message["Subject"] = subject
+        message.set_content(body)
+
+        if self.settings.use_ssl:
+            smtp_cls = smtplib.SMTP_SSL
+        else:
+            smtp_cls = smtplib.SMTP
+
+        with smtp_cls(self.settings.host, port, timeout=30) as client:
+            if self.settings.use_tls and not self.settings.use_ssl:
+                client.starttls()
+            if self.settings.username and self.settings.password:
+                client.login(self.settings.username, self.settings.password)
+            client.send_message(message)
+
+
+def generate_verification_code() -> str:
+    return f"{secrets.randbelow(1_000_000):06d}"
+
+
+USERNAME_PATTERN = re.compile(r"^[A-Za-z0-9._-]{3,32}$")
+PASSWORD_SPECIAL_PATTERN = re.compile(r"[^A-Za-z0-9]")
+
+
+def validate_username(username: str) -> Tuple[bool, str]:
+    if not username:
+        return False, "Username is required."
+    if not USERNAME_PATTERN.fullmatch(username):
+        return (
+            False,
+            "Username must be 3-32 characters and can only include letters, numbers, periods, underscores, or dashes.",
+        )
+    return True, ""
+
+
+def validate_password(password: str) -> Tuple[bool, str]:
+    if len(password) < 12:
+        return False, "Password must be at least 12 characters long."
+    if password.lower() == password or password.upper() == password:
+        return False, "Password must include a mix of uppercase and lowercase letters."
+    if not any(ch.isdigit() for ch in password):
+        return False, "Password must include at least one number."
+    if not PASSWORD_SPECIAL_PATTERN.search(password):
+        return False, "Password must include at least one special character."
+    return True, ""
+
+
+def validate_email(email: str) -> Tuple[bool, str]:
+    if not email:
+        return False, "Email is required."
+    email_lower = email.lower()
+    if not email_lower.endswith("@nyu.edu"):
+        return False, "A valid NYU email ending with @nyu.edu is required."
+    return True, ""
+
+
+class AuthService:
+    """Encapsulates user registration, authentication, and password reset flows."""
+
+    verification_ttl = timedelta(minutes=15)
+
+    def __init__(self, store: PolicyStore, email_sender: EmailSender, hasher: SecretHasher) -> None:
+        self.store = store
+        self.email_sender = email_sender
+        self.hasher = hasher
+
+    def initiate_registration(self, username: str, email: str) -> Tuple[bool, str, Dict[str, Any]]:
+        username_normalized = username.strip().lower()
+        email_normalized = email.strip().lower()
+
+        valid_username, username_msg = validate_username(username_normalized)
+        if not valid_username:
+            return False, username_msg, {}
+
+        valid_email, email_msg = validate_email(email_normalized)
+        if not valid_email:
+            return False, email_msg, {}
+
+        with self.store.session() as session:
+            existing_username = session.execute(
+                select(UserAccount).where(UserAccount.username == username_normalized)
+            ).scalar_one_or_none()
+            existing_email = session.execute(
+                select(UserAccount).where(UserAccount.email == email_normalized)
+            ).scalar_one_or_none()
+
+            if existing_username and existing_username.email != email_normalized:
+                return False, "Username is already in use by another account.", {}
+
+            if existing_email and existing_email.username != username_normalized:
+                return False, "Email is already registered; try logging in or resetting your password.", {}
+
+            if existing_username and existing_username.is_verified:
+                return False, "Account already exists. Please log in instead.", {}
+
+            if existing_email and existing_email.is_verified:
+                return False, "Email already verified. Use the login form or reset your password.", {}
+
+            code = generate_verification_code()
+            hashed_code = self.hasher.hash_secret(code)
+            now = datetime.now(timezone.utc)
+
+            if existing_username:
+                user = existing_username
+                user.email = email_normalized
+                user.verification_hash = hashed_code
+                user.verification_sent_at = now
+                user.is_verified = False
+            elif existing_email:
+                user = existing_email
+                user.username = username_normalized
+                user.verification_hash = hashed_code
+                user.verification_sent_at = now
+                user.is_verified = False
+            else:
+                user = UserAccount(
+                    username=username_normalized,
+                    email=email_normalized,
+                    password_hash=None,
+                    is_verified=False,
+                    verification_hash=hashed_code,
+                    verification_sent_at=now,
+                )
+                session.add(user)
+
+            session.flush()
+
+        try:
+            self.email_sender.send_verification_code(email_normalized, code, username=username_normalized)
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logger.exception("Failed to send verification email: %s", exc)
+            return (
+                False,
+                "Unable to send verification email. Please try again later or contact support.",
+                {},
+            )
+
+        return True, "Verification code sent. Check your NYU email and enter the 6-digit code.", {
+            "username": username_normalized,
+            "email": email_normalized,
+        }
+
+    def complete_registration(self, state: Dict[str, Any], code: str, password: str) -> Tuple[bool, str]:
+        username = state.get("username")
+        email = state.get("email")
+        if not username or not email:
+            return False, "Start the registration process before entering the verification code."
+
+        with self.store.session() as session:
+            user = session.execute(
+                select(UserAccount).where(UserAccount.username == username)
+            ).scalar_one_or_none()
+            if not user or user.email != email:
+                return False, "Registration session not found. Please restart the sign-up process."
+
+            if not user.verification_hash or not user.verification_sent_at:
+                return False, "Request a new verification code to continue registration."
+
+            if datetime.now(timezone.utc) - user.verification_sent_at > self.verification_ttl:
+                return False, "Verification code expired. Request a new one."
+
+            code_normalized = code.strip()
+            if not code_normalized:
+                return False, "Enter the 6-digit verification code that was emailed to you."
+
+            if not self.hasher.verify_secret(code_normalized, user.verification_hash):
+                return False, "Invalid verification code."
+
+            strong, message = validate_password(password)
+            if not strong:
+                return False, message
+
+            user.password_hash = self.hasher.hash_secret(password)
+            user.is_verified = True
+            user.verification_hash = None
+            user.verification_sent_at = None
+            user.reset_code_hash = None
+            user.reset_requested_at = None
+            session.flush()
+
+        return True, "Registration complete. You can now log in with your username and password."
+
+    def authenticate(self, username: str, password: str) -> Tuple[bool, str, Dict[str, Any] | None]:
+        username_normalized = username.strip().lower()
+        password = password or ""
+
+        with self.store.session() as session:
+            user = session.execute(
+                select(UserAccount).where(UserAccount.username == username_normalized)
+            ).scalar_one_or_none()
+
+            if not user:
+                return False, "Account not found. Check your username or register for a new account.", None
+
+            if not user.is_verified:
+                return False, "Account not verified. Complete registration before logging in.", None
+
+            if not user.password_hash or not self.hasher.verify_secret(password, user.password_hash):
+                return False, "Incorrect password. Try again or reset your password.", None
+
+        return True, "Login successful.", {
+            "username": username_normalized,
+            "email": user.email,
+        }
+
+    def initiate_password_reset(self, email: str) -> Tuple[bool, str, Dict[str, Any]]:
+        email_normalized = email.strip().lower()
+        valid_email, email_msg = validate_email(email_normalized)
+        if not valid_email:
+            return False, email_msg, {}
+
+        with self.store.session() as session:
+            user = session.execute(
+                select(UserAccount).where(UserAccount.email == email_normalized)
+            ).scalar_one_or_none()
+
+            if not user or not user.is_verified:
+                return False, "No verified account found for that email. Register first if you're new.", {}
+
+            code = generate_verification_code()
+            user.reset_code_hash = self.hasher.hash_secret(code)
+            user.reset_requested_at = datetime.now(timezone.utc)
+            session.flush()
+            username = user.username
+
+        try:
+            self.email_sender.send_reset_code(email_normalized, code, username=username)
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logger.exception("Failed to send reset email: %s", exc)
+            return False, "Unable to send reset email right now. Try again later.", {}
+
+        return True, "Password reset email sent. Enter the 6-digit code from your inbox.", {
+            "email": email_normalized,
+        }
+
+    def complete_password_reset(self, state: Dict[str, Any], code: str, password: str) -> Tuple[bool, str]:
+        email = state.get("email")
+        if not email:
+            return False, "Start the reset process before entering the verification code."
+
+        with self.store.session() as session:
+            user = session.execute(select(UserAccount).where(UserAccount.email == email)).scalar_one_or_none()
+            if not user or not user.reset_code_hash or not user.reset_requested_at:
+                return False, "Request a new reset code to continue."
+
+            if datetime.now(timezone.utc) - user.reset_requested_at > self.verification_ttl:
+                return False, "Reset code expired. Request a new one."
+
+            code_normalized = code.strip()
+            if not code_normalized:
+                return False, "Enter the 6-digit verification code sent to your email."
+
+            if not self.hasher.verify_secret(code_normalized, user.reset_code_hash):
+                return False, "Invalid verification code."
+
+            strong, message = validate_password(password)
+            if not strong:
+                return False, message
+
+            user.password_hash = self.hasher.hash_secret(password)
+            user.reset_code_hash = None
+            user.reset_requested_at = None
+            session.flush()
+
+        return True, "Password updated. You can now log in with your new credentials."
+

--- a/config.py
+++ b/config.py
@@ -16,6 +16,14 @@ class Settings:
     database_url: str
     chunk_size: int = 220
     chunk_overlap: int = 40
+    smtp_host: str | None = None
+    smtp_port: int | None = None
+    smtp_username: str | None = None
+    smtp_password: str | None = None
+    smtp_from_email: str | None = None
+    smtp_use_tls: bool = False
+    smtp_use_ssl: bool = False
+    smtp_dev_mode: bool = False
 
 
 def load_settings() -> Settings:
@@ -43,6 +51,15 @@ def load_settings() -> Settings:
             "to enable persistence."
         )
 
+    def _bool(name: str, default: bool = False) -> bool:
+        value = os.getenv(name)
+        if value is None:
+            return default
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+
+    smtp_port = os.getenv("SMTP_PORT")
+    smtp_port_int = int(smtp_port) if smtp_port else None
+
     return Settings(
         openai_api_key=api_key,
         openai_organization=os.getenv("OPENAI_ORGANIZATION"),
@@ -52,4 +69,12 @@ def load_settings() -> Settings:
         database_url=database_url,
         chunk_size=int(os.getenv("CHUNK_SIZE", "220")),
         chunk_overlap=int(os.getenv("CHUNK_OVERLAP", "40")),
+        smtp_host=os.getenv("SMTP_HOST"),
+        smtp_port=smtp_port_int,
+        smtp_username=os.getenv("SMTP_USERNAME"),
+        smtp_password=os.getenv("SMTP_PASSWORD"),
+        smtp_from_email=os.getenv("SMTP_FROM_EMAIL"),
+        smtp_use_tls=_bool("SMTP_USE_TLS", default=True),
+        smtp_use_ssl=_bool("SMTP_USE_SSL", default=False),
+        smtp_dev_mode=_bool("SMTP_DEV_MODE", default=False),
     )

--- a/policy_store.py
+++ b/policy_store.py
@@ -4,10 +4,23 @@ from __future__ import annotations
 import contextlib
 import json
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Iterator, List, Sequence
 
 import numpy as np
-from sqlalchemy import Column, ForeignKey, Integer, String, Text, create_engine, delete, select
+from sqlalchemy import (
+    Boolean,
+    Column,
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+    create_engine,
+    delete,
+    func,
+    select,
+)
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Mapped, Session, declarative_base, mapped_column, relationship, sessionmaker
 from sqlalchemy.types import TypeDecorator
@@ -99,6 +112,30 @@ class Embedding(Base):
 
     chunk: Mapped[Chunk] = relationship("Chunk", back_populates="embedding")
 
+
+class UserAccount(Base):
+    __tablename__ = "users"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    username: Mapped[str] = mapped_column(String(64), unique=True, nullable=False, index=True)
+    email: Mapped[str] = mapped_column(String(320), unique=True, nullable=False, index=True)
+    password_hash: Mapped[str | None] = mapped_column(String(512), nullable=True)
+    is_verified: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    verification_hash: Mapped[str | None] = mapped_column(String(512), nullable=True)
+    verification_sent_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    reset_code_hash: Mapped[str | None] = mapped_column(String(512), nullable=True)
+    reset_requested_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
 
 @dataclass
 class RetrievedChunk:


### PR DESCRIPTION
## Summary
- add an authentication service that handles registration, login, and password reset with NYU email verification and secure secret hashing
- extend the Gradio UI with login, registration, and recovery tabs that gate chatbot access until a student signs in
- expand persistence and configuration to store user accounts and support SMTP-based notifications

## Testing
- python -m compileall auth_service.py app.py config.py policy_store.py

------
https://chatgpt.com/codex/tasks/task_e_68daeb92398c8324bb4ac411ee137524